### PR TITLE
Clean up seed data

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,8 +13,11 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         Eloquent::unguard();
+        DB::statement('SET FOREIGN_KEY_CHECKS = 0');
 
         $this->call('UserTableSeeder');
         $this->call('TalksSeeder');
+
+        DB::statement('SET FOREIGN_KEY_CHECKS = 1');
     }
 }

--- a/database/seeds/TalksSeeder.php
+++ b/database/seeds/TalksSeeder.php
@@ -6,9 +6,9 @@ class TalksSeeder extends Seeder
 {
     public function run()
     {
-        DB::table('talk_version_revisions')->truncate();
-        DB::table('talk_versions')->truncate();
-        DB::table('talks')->truncate();
+        TalkVersionRevision::truncate();
+        TalkVersion::truncate();
+        Talk::truncate();
 
         $talks = [
             [

--- a/database/seeds/TalksSeeder.php
+++ b/database/seeds/TalksSeeder.php
@@ -10,90 +10,47 @@ class TalksSeeder extends Seeder
         TalkVersion::truncate();
         Talk::truncate();
 
-        $talks = [
-            [
-                'id' => '03f22222-8888-40da-b571-e982570247f',
-                'title' => 'My Great Talk',
-                'author_id' => 1,
-                'created_at' => '2013-11-27 15:54:41'
-            ],
-            [
-                'id' => '03f22222-8888-40da-b571-e982570247d',
-                'title' => 'My Terrible Talk',
-                'author_id' => 1,
-                'created_at' => '2013-10-27 15:54:41'
-            ]
-        ];
+        $author = User::first();
 
-        foreach ($talks as &$talk) {
-            $talk['updated_at'] = new DateTime;
-        }
+        $greatTalk = $author->talks()->create(['title' => 'My Great Talk', 'description' => 'Description of the talk']);
+        $terribleTalk = $author->talks()->create(['title' => 'My Terrible Talk', 'description' => 'Description of the talk']);
 
-        DB::table('talks')
-            ->insert($talks);
+        $author->talks()->saveMany([$greatTalk, $terribleTalk]);
 
+        $greatTalkVersion1 = $greatTalk->versions()->create(['nickname' => 'php conf version', 'created_at' => '2013-11-27 15:54:41']);
+        $greatTalkVersion2 = $greatTalk->versions()->create(['nickname' => 'frontend conf version', 'created_at' => '2013-11-28 15:54:41']);
 
-        $versions = [
-            [
-                'id' => '03f22222-6a15-40da-b571-e982570247f',
-                'nickname' => 'php conf version',
-                'talk_id' => '03f22222-8888-40da-b571-e982570247f',
-                'created_at' => '2013-11-27 15:54:41'
-            ],
-            [
-                'id' => '03f22222-6a15-40da-b571-e9825702471',
-                'nickname' => 'frontend conf version',
-                'talk_id' => '03f22222-8888-40da-b571-e982570247f',
-                'created_at' => '2013-11-28 15:54:41'
-            ]
-        ];
+        $greatTalkVersion1->revisions()->create([
+            'title' => 'My great talk',
+            'description' => 'Description of the talk',
+            'type' => 'seminar',
+            'level' => 'intermediate',
+            'length' => '45',
+            'outline' => 'Talk outline',
+            'organizer_notes' => 'Organizer notes',
+            'created_at' => '2013-11-29 15:54:41'
+        ]);
 
-        foreach ($versions as &$version) {
-            $version['updated_at'] = new DateTime;
-        }
+        $greatTalkVersion1->revisions()->create([
+            'title' => 'My awesome talk',
+            'description' => 'Description of the talk',
+            'type' => 'seminar',
+            'level' => 'intermediate',
+            'length' => '45',
+            'outline' => 'Talk outline',
+            'organizer_notes' => 'Organizer notes',
+            'created_at' => '2013-11-27 15:54:41'
+        ]);
 
-        DB::table('talk_versions')
-            ->insert($versions);
-
-
-        $revisions = [
-            [
-                'id' => '03f2ae25-6a15-40da-b571-e982570247fa',
-                'title' => 'My great talk',
-                'description' => 'Description of the talk',
-                'type' => 'seminar',
-                'level' => 'intermediate',
-                'length' => '45',
-                'talk_version_id' => '03f22222-6a15-40da-b571-e982570247f',
-                'created_at' => '2013-11-29 15:54:41'
-            ],
-            [
-                'id' => '03f2ae25-6a15-40da-b571-e982570247fd',
-                'title' => 'My awesome talk',
-                'description' => 'Description of the talk',
-                'type' => 'seminar',
-                'level' => 'intermediate',
-                'length' => '45',
-                'talk_version_id' => '03f22222-6a15-40da-b571-e982570247f',
-                'created_at' => '2013-11-27 15:54:41'
-            ],
-            [
-                'id' => '03f2ae25-6a15-40da-b571-e982570247f5',
-                'title' => 'My awesome talk',
-                'description' => 'Description of the talk',
-                'type' => 'seminar',
-                'level' => 'intermediate',
-                'length' => '45',
-                'talk_version_id' => '03f22222-6a15-40da-b571-e9825702471',
-                'created_at' => '2013-11-28 15:54:41'
-            ],
-        ];
-
-        foreach ($revisions as &$revision) {
-            $revision['updated_at'] = new DateTime;
-        }
-
-        DB::table('talk_version_revisions')
-            ->insert($revisions);
+        $greatTalkVersion2->revisions()->create([
+            'title' => 'My awesome talk',
+            'description' => 'Description of the talk',
+            'type' => 'seminar',
+            'level' => 'intermediate',
+            'length' => '45',
+            'outline' => 'Talk outline',
+            'organizer_notes' => 'Organizer notes',
+            'created_at' => '2013-11-28 15:54:41'
+        ]);
     }
 }

--- a/database/seeds/TalksSeeder.php
+++ b/database/seeds/TalksSeeder.php
@@ -60,8 +60,8 @@ class TalksSeeder extends Seeder
             ->insert($versions);
 
 
-        $revisions = array(
-            array(
+        $revisions = [
+            [
                 'id' => '03f2ae25-6a15-40da-b571-e982570247fa',
                 'title' => 'My great talk',
                 'description' => 'Description of the talk',
@@ -70,8 +70,8 @@ class TalksSeeder extends Seeder
                 'length' => '45',
                 'talk_version_id' => '03f22222-6a15-40da-b571-e982570247f',
                 'created_at' => '2013-11-29 15:54:41'
-            ),
-            array(
+            ],
+            [
                 'id' => '03f2ae25-6a15-40da-b571-e982570247fd',
                 'title' => 'My awesome talk',
                 'description' => 'Description of the talk',
@@ -80,8 +80,8 @@ class TalksSeeder extends Seeder
                 'length' => '45',
                 'talk_version_id' => '03f22222-6a15-40da-b571-e982570247f',
                 'created_at' => '2013-11-27 15:54:41'
-            ),
-            array(
+            ],
+            [
                 'id' => '03f2ae25-6a15-40da-b571-e982570247f5',
                 'title' => 'My awesome talk',
                 'description' => 'Description of the talk',
@@ -90,8 +90,8 @@ class TalksSeeder extends Seeder
                 'length' => '45',
                 'talk_version_id' => '03f22222-6a15-40da-b571-e9825702471',
                 'created_at' => '2013-11-28 15:54:41'
-            ),
-        );
+            ],
+        ];
 
         foreach ($revisions as &$revision) {
             $revision['updated_at'] = new DateTime;

--- a/database/seeds/TalksSeeder.php
+++ b/database/seeds/TalksSeeder.php
@@ -6,13 +6,9 @@ class TalksSeeder extends Seeder
 {
     public function run()
     {
-        DB::statement('SET FOREIGN_KEY_CHECKS = 0');
-
         DB::table('talk_version_revisions')->truncate();
         DB::table('talk_versions')->truncate();
         DB::table('talks')->truncate();
-
-        DB::statement('SET FOREIGN_KEY_CHECKS = 1');
 
         $talks = [
             [

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -6,10 +6,8 @@ class UserTableSeeder extends Seeder
 {
     public function run()
     {
-        DB::statement('SET FOREIGN_KEY_CHECKS = 0');
         User::truncate();
 
-        DB::statement('SET FOREIGN_KEY_CHECKS = 1');
         User::create([
             'email' => 'matt@savemyproposals.com',
             'password' => Hash::make('password'),

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -7,18 +7,14 @@ class UserTableSeeder extends Seeder
     public function run()
     {
         DB::statement('SET FOREIGN_KEY_CHECKS = 0');
-
-        DB::table('users')->truncate();
+        User::truncate();
 
         DB::statement('SET FOREIGN_KEY_CHECKS = 1');
-
-        DB::table('users')->insert(array(
-            array(
-                'email' => 'matt@savemyproposals.com',
-                'password' => Hash::make('password'),
-                'first_name' => 'Matt',
-                'last_name' => 'Stauffer',
-            )
-        ));
+        User::create([
+            'email' => 'matt@savemyproposals.com',
+            'password' => Hash::make('password'),
+            'first_name' => 'Matt',
+            'last_name' => 'Stauffer',
+        ]);
     }
 }


### PR DESCRIPTION
* Lots of seeds were missing required fields, which was failing in MySQL strict mode, and would fail in Postgres and SQLite
* Reduced duplication of knowledge of things like table names, IDs, etc. to make the seeds easier to maintain

**Question:** If we are using revisions, does the talks table itself need things like "description"? Shouldn't that just be in the revision?
