### PR TITLE
Rename URL mutator to link

### DIFF
--- a/app/Console/Commands/TweetImportantCFPDates.php
+++ b/app/Console/Commands/TweetImportantCFPDates.php
@@ -62,7 +62,7 @@ class TweetImportantCFPDates extends Command
         return sprintf(
             $message,
             $title,
-            $conference->url
+            $conference->link
         );
     }
 
@@ -81,7 +81,7 @@ class TweetImportantCFPDates extends Command
         return sprintf(
             $message,
             $title,
-            $conference->url
+            $conference->link
         );
     }
 

--- a/app/models/Conference.php
+++ b/app/models/Conference.php
@@ -140,7 +140,7 @@ class Conference extends UuidBase
         return (! is_null($this->cfp_starts_at)) && (! is_null($this->cfp_ends_at));
     }
 
-    public function getUrlAttribute()
+    public function getLinkAttribute()
     {
         return route('conferences.show', $this->id);
     }


### PR DESCRIPTION
Temporary fix until we decide what names to use to differentiate
between external conference URLs and internal conference URLs.