### PR TITLE
Drop external code coverage from scrutinizer config

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -27,8 +27,6 @@ tools:
         configuration_file: null
         suffixes:
             - php
-    external_code_coverage:
-        timeout: 600 # Timeout in seconds.
 changetracking:
     bug_patterns:
         - '\bfix(?:es|ed)?\b'


### PR DESCRIPTION
Testing to see if this makes Scrutinizer go green again. If so, let's merge.