### PR TITLE
Add dashboard

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -21,7 +21,7 @@ class AuthController extends BaseController
     {
         if (Auth::attempt(array('email' => Input::get('email'), 'password' => Input::get('password')))) {
             Session::flash('message', 'Successfully logged in.');
-            return Redirect::intended('/talks');
+            return Redirect::intended('/dashboard');
         }
 
         Session::flash('error-message', 'Invalid login credentials.');

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symposium\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symposium\Http\Controllers\Controller;
+use Symposium\Http\Requests;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $talks = Auth::user()->talks->sortBy(function ($talk) {
+            return strtolower($talk->current()->title);
+        });
+
+        return view('dashboard')
+            ->with('bios', Auth::user()->bios)
+            ->with('talks', $talks);
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -45,6 +45,7 @@ Route::group(['middleware' => 'auth'], function () {
     Route::get('talks/{id}/delete', 'TalksController@destroy');
     Route::get('conferences/{id}/delete', 'ConferencesController@destroy');
 
+    Route::get('dashboard', 'DashboardController@index');
     Route::resource('talks', 'TalksController');
     Route::resource('conferences', 'ConferencesController');
     Route::resource('bios', 'BiosController');

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -63,6 +63,11 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function talks()
     {
         return $this->hasMany('Talk', 'author_id');
+        /* @todo can we do this somehow?
+            ->orderBy(function ($talk) {
+                return strtolower($talk->current()->title);
+            });
+        */
     }
 
     public function bios()

--- a/resources/views/bios/index.blade.php
+++ b/resources/views/bios/index.blade.php
@@ -15,31 +15,7 @@
         <ul class="list-bios">
             @forelse ($bios as $bio)
                 <li>
-                    <h3><a href="/bios/{{ $bio->id }}">{{ $bio->nickname }}</a></h3>
-                    <p>{{ $bio->preview }}</p>
-
-                    <div class="modal fade bio-modal" id="modal-{{ $bio->id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-                      <div class="modal-dialog">
-                        <div class="modal-content">
-                          <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                            <h4 class="modal-title" id="myModalLabel">Copy bio</h4>
-                          </div>
-                          <div class="modal-body">
-                            <textarea class="select-me" style="width: 100%; height: 10em;">{{ $bio->body }}</textarea>
-                          </div>
-                          <div class="modal-footer">
-                            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    <p>
-                    <a href="/bios/{{ $bio->id }}/delete" data-confirm="confirm"><button type="button" class="btn btn-xs btn-danger">Delete</button></a>
-                    <a href="/bios/{{ $bio->id }}/edit"><button type="button" class="btn btn-xs btn-default">Edit</button></a>
-                    <a href="#" data-toggle="modal" data-target="#modal-{{ $bio->id }}"><button type="button" class="btn btn-xs btn-default">Copy</button></a>
-                    </p>
+                    @include ('partials.bio-in-list', ['bio' => $bio])
                 </li>
             @empty
                 <li>No bios yet.</li>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,45 @@
+@extends('layout')
+
+@section('content')
+
+    <div class="container">
+        <ol class="breadcrumb">
+            <li><a href="/">Home</a></li>
+        </ol>
+
+        <div class="row">
+            <div class="col-md-6">
+                <a href="{{ route('talks.index') }}"><h2>My Talks</h2></a>
+
+                <p class="list-sort">(sorted by title)</p>
+                <ul class="list-talks">
+                    @forelse ($talks as $talk)
+                        <li>
+                            @include ('partials.talk-in-list', ['talk' => $talk])
+                        </li>
+                    @empty
+                        <li>
+                            No talks yet.
+                        </li>
+                    @endforelse
+                </ul>
+            </div>
+            <div class="col-md-6">
+                <a href="{{ route('bios.index') }}"><h2>My Bios</h2></a>
+
+                <p class="list-sort">(sorted by title)</p>
+                <ul class="list-talks">
+                    @forelse ($bios as $bio)
+                        <li>
+                            @include ('partials.bio-in-list')
+                        </li>
+                    @empty
+                        <li>
+                            No bios yet.
+                        </li>
+                    @endforelse
+                </ul>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/partials/bio-in-list.blade.php
+++ b/resources/views/partials/bio-in-list.blade.php
@@ -1,0 +1,25 @@
+<h3><a href="/bios/{{ $bio->id }}">{{ $bio->nickname }}</a></h3>
+<p>{{ $bio->preview }}</p>
+
+<div class="modal fade bio-modal" id="modal-{{ $bio->id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="myModalLabel">Copy bio</h4>
+            </div>
+            <div class="modal-body">
+                <textarea class="select-me" style="width: 100%; height: 10em;">{{ $bio->body }}</textarea>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<p>
+    <a href="/bios/{{ $bio->id }}/delete" data-confirm="confirm"><button type="button" class="btn btn-xs btn-danger">Delete</button></a>
+    <a href="/bios/{{ $bio->id }}/edit"><button type="button" class="btn btn-xs btn-default">Edit</button></a>
+    <a href="#" data-toggle="modal" data-target="#modal-{{ $bio->id }}"><button type="button" class="btn btn-xs btn-default">Copy</button></a>
+</p>

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -1,6 +1,7 @@
 <nav>
     <ul class="primary-header__meta-nav">
         @if (Auth::check())
+            <li><a href="/dashboard">Dashboard</a></li>
             <li><a href="/bios">Bios</a></li>
             <li><a href="/conferences">Conferences</a></li>
             <li><a href="/talks">Talks</a></li>

--- a/resources/views/partials/talk-in-list.blade.php
+++ b/resources/views/partials/talk-in-list.blade.php
@@ -1,0 +1,2 @@
+<h3><a href="/talks/{{ $talk->id }}">{{ $talk->current()->title }}</a></h3>
+<p class="talk-meta"><i>{{ $talk->created_at->toFormattedDateString()  }}</i> | {{ $talk->current()->length }}-minute {{ $talk->current()->level }} {{ $talk->current()->type }}</p>

--- a/resources/views/talks/index.blade.php
+++ b/resources/views/talks/index.blade.php
@@ -17,12 +17,15 @@
         <p class="list-sort">Sort: <a href="/talks?sort=alpha"{{ $sorting_talk['alpha'] }}>Title</a> | <a
                     href="/talks?sort=date"{{ $sorting_talk['date'] }}>Date</a></p>
         <ul class="list-talks">
-            @foreach ($talks as $talk)
+            @forelse ($talks as $talk)
                 <li>
-                    <h3><a href="/talks/{{ $talk->id }}">{{ $talk->current()->title }}</a></h3>
-                    <p class="talk-meta"><i>{{ $talk->created_at->toFormattedDateString()  }}</i> | {{ $talk->current()->length }}-minute {{ $talk->current()->level }} {{ $talk->current()->type }}</p>
+                    @include ('partials.talk-in-list', ['talk' => $talk])
                 </li>
-            @endforeach
+            @empty
+                <li>
+                    No talks yet.
+                </li>
+            @endforelse
         </ul>
     </div>
 @stop


### PR DESCRIPTION
Frustrating that it currently dumps you to the talks page when you log in. So I added a dashboard route and view for us to get creative with.

One definite use case: I want less clicks to access a bio. But I can't say this is the perfect dashboard. Definitely would love to hear thoughts.

(Among other things, it shows how weird it is that bios get buttons in their list and talks don't...)

![image](https://cloud.githubusercontent.com/assets/151829/8769356/38ac031c-2e69-11e5-8131-f6d92e219c0e.png)
