### PR TITLE
Capitalize GitHub properly in footer

### DIFF
--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -3,7 +3,7 @@
 
     <footer>
         <p>&copy; <a href="http://tighten.co/">Tighten Co.</a> {{ date('Y') }}
-            | source on <a href="https://github.com/tightenco/symposium">Github</a>
+            | source on <a href="https://github.com/tightenco/symposium">GitHub</a>
             | roadmap/bugs on <a href="https://waffle.io/tightenco/symposium">Waffle.io</a></p>
         </p>
     </footer>


### PR DESCRIPTION
I don't trust any tool that uses a lower case H in GitHub :)