### PR TITLE
Fix issue with conferences not sorting

### DIFF
--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -66,13 +66,13 @@ class ConferencesController extends BaseController
 
         switch (Input::get('sort')) {
             case 'date':
-                $conferences->sortBy(function (Conference $model) {
+                $conferences = $conferences->sortBy(function (Conference $model) {
                     return $model->starts_at;
                 });
                 break;
             case 'closing_next':
                 // Forces closed CFPs to the end. I feel dirty. Even dirtier with the 500 thing.
-                $conferences
+                $conferences = $conferences
                     ->sortBy(function (Conference $model) {
                         if ($model->cfp_ends_at > Carbon::now()) {
                             return $model->cfp_ends_at;
@@ -86,7 +86,7 @@ class ConferencesController extends BaseController
             case 'alpha':
                 // Pass through
             default:
-                $conferences->sortBy(function (Conference $model) {
+                $conferences = $conferences->sortBy(function (Conference $model) {
                     return strtolower($model->title);
                 });
                 break;


### PR DESCRIPTION
This may be related to a Laravel update, but `sortBy` on a collection doesn't mutate the collection, and we weren't storing the return value so our sorted list of talks was not actually getting passed to the view.