### PR TITLE
Don't prefix talk in breadcrumbs with 'Talk:'

### DIFF
--- a/resources/views/talks/edit.blade.php
+++ b/resources/views/talks/edit.blade.php
@@ -6,7 +6,7 @@
         <ol class="breadcrumb">
             <li><a href="{{ route('dashboard') }}">Home</a></li>
             <li><a href="{{ route('talks.index') }}">Talks</a></li>
-            <li><a href="{{ route('talks.show', ['id' => $current->talk_id]) }}">Talk: {{ $current->title }}</a></li>
+            <li><a href="{{ route('talks.show', ['id' => $current->talk_id]) }}">{{ $current->title }}</a></li>
         </ol>
 
         <h1>Edit Talk Nickname</h1>

--- a/resources/views/talks/show.blade.php
+++ b/resources/views/talks/show.blade.php
@@ -6,7 +6,7 @@
         <ol class="breadcrumb">
             <li><a href="{{ route('dashboard') }}">Home</a></li>
             <li><a href="{{ route('talks.index') }}">Talks</a></li>
-            <li><a href="{{ route('talks.show', ['id' => $talk->id]) }}">Talk: {{ $current->title }}</a></li>
+            <li><a href="{{ route('talks.show', ['id' => $talk->id]) }}">{{ $current->title }}</a></li>
         </ol>
 
         <div class="pull-right">


### PR DESCRIPTION
Looks weird when it says "Home / Talks / Talk: Leveraging Laravel". I think it's intuitive that everything under "Talks /" is going to be a talk title :)