### PR TITLE
Fix lack of Slack configuration causing errors

### DIFF
--- a/app/Handlers/Events/SlackSubscriber.php
+++ b/app/Handlers/Events/SlackSubscriber.php
@@ -6,8 +6,11 @@ class SlackSubscriber
 {
     public function subscribe($events)
     {
-        $events->listen('new-signup', [$this, 'onNewSignup']);
-        $events->listen('new-conference', [$this, 'onNewConference']);
+        $endpoint = Slack::getEndpoint();
+        if (!empty($endpoint)) {
+            $events->listen('new-signup', [$this, 'onNewSignup']);
+            $events->listen('new-conference', [$this, 'onNewConference']);
+        }
     }
 
     public function onNewSignup($user)

--- a/app/Handlers/Events/SlackSubscriber.php
+++ b/app/Handlers/Events/SlackSubscriber.php
@@ -6,11 +6,12 @@ class SlackSubscriber
 {
     public function subscribe($events)
     {
-        $endpoint = Slack::getEndpoint();
-        if (!empty($endpoint)) {
-            $events->listen('new-signup', [$this, 'onNewSignup']);
-            $events->listen('new-conference', [$this, 'onNewConference']);
+        if (empty(Slack::getEndpoint())) {
+            return;
         }
+
+        $events->listen('new-signup', [$this, 'onNewSignup']);
+        $events->listen('new-conference', [$this, 'onNewConference']);
     }
 
     public function onNewSignup($user)


### PR DESCRIPTION
There is [no default endpoint](https://github.com/tightenco/symposium/blob/b0392c495faad361f699d0144142dcb4e9cbd030/config/slack.php#L16) configured for Slack integration. This causes a blocking error for [any events that are syndicated to Slack](https://github.com/tightenco/symposium/blob/b0392c495faad361f699d0144142dcb4e9cbd030/app/Handlers/Events/SlackSubscriber.php#L9-L10), such as attempting to create a new user account. Below is an example stack trace of such an error. This change corrects this issue by adding a check for a non-empty endpoint in the Slack subscriber before registering event handlers.

```
[2015-10-25 11:41:51] production.ERROR: exception 'GuzzleHttp\Ring\Exception\RingException' with message 'cURL error 3: <url> malformed' in symposium/vendor/guzzlehttp/ringphp/src/Client/CurlFactory.php:127
Stack trace:
0 symposium/vendor/guzzlehttp/ringphp/src/Client/CurlFactory.php(91): GuzzleHttp\Ring\Client\CurlFactory::createErrorResponse(Array, Array, Array)
1 symposium/vendor/guzzlehttp/ringphp/src/Client/CurlHandler.php(96): GuzzleHttp\Ring\Client\CurlFactory::createResponse(Array, Array, Array, Array, Resource id #179)
2 symposium/vendor/guzzlehttp/ringphp/src/Client/CurlHandler.php(68): GuzzleHttp\Ring\Client\CurlHandler->_invokeAsArray(Array)
3 symposium/vendor/guzzlehttp/ringphp/src/Client/Middleware.php(54): GuzzleHttp\Ring\Client\CurlHandler->__invoke(Array)
4 symposium/vendor/guzzlehttp/ringphp/src/Client/Middleware.php(30): GuzzleHttp\Ring\Client\Middleware::GuzzleHttp\Ring\Client\{closure}(Array)
5 symposium/vendor/guzzlehttp/guzzle/src/RequestFsm.php(129): GuzzleHttp\Ring\Client\Middleware::GuzzleHttp\Ring\Client\{closure}(Array)
6 symposium/vendor/guzzlehttp/guzzle/src/Client.php(165): GuzzleHttp\RequestFsm->__invoke(Object(GuzzleHttp\Transaction))
7 symposium/vendor/guzzlehttp/guzzle/src/Client.php(150): GuzzleHttp\Client->send(Object(GuzzleHttp\Message\Request))
8 symposium/vendor/maknz/slack/src/Client.php(357): GuzzleHttp\Client->post(NULL, Array)
9 symposium/vendor/maknz/slack/src/Message.php(410): Maknz\Slack\Client->sendMessage(Object(Maknz\Slack\Message))
10 [internal function]: Maknz\Slack\Message->send('*New user signu...')
11 symposium/vendor/maknz/slack/src/Client.php(123): call_user_func_array(Array, Array)
12 symposium/bootstrap/cache/compiled.php(5575): Maknz\Slack\Client->__call('send', Array)
13 symposium/bootstrap/cache/compiled.php(5575): Maknz\Slack\Client->send('*New user signu...')
14 symposium/app/Handlers/Events/SlackSubscriber.php(15): Illuminate\Support\Facades\Facade::__callStatic('send', Array)
15 symposium/app/Handlers/Events/SlackSubscriber.php(15): Maknz\Slack\Facades\Slack::send('*New user signu...')
16 [internal function]: Symposium\Handlers\Events\SlackSubscriber->onNewSignup(Object(User))
17 symposium/bootstrap/cache/compiled.php(9571): call_user_func_array(Array, Array)
18 symposium/bootstrap/cache/compiled.php(5577): Illuminate\Events\Dispatcher->fire('new-signup', Array)
19 symposium/app/Http/Controllers/AccountController.php(64): Illuminate\Support\Facades\Facade::__callStatic('fire', Array)
20 symposium/app/Http/Controllers/AccountController.php(64): Illuminate\Support\Facades\Event::fire('new-signup', Array)
21 [internal function]: Symposium\Http\Controllers\AccountController->store()
22 symposium/bootstrap/cache/compiled.php(8706): call_user_func_array(Array, Array)
23 symposium/bootstrap/cache/compiled.php(8774): Illuminate\Routing\Controller->callAction('store', Array)
24 symposium/bootstrap/cache/compiled.php(8754): Illuminate\Routing\ControllerDispatcher->call(Object(Symposium\Http\Controllers\AccountController), Object(Illuminate\Routing\Route), 'store')
25 [internal function]: Illuminate\Routing\ControllerDispatcher->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
26 symposium/bootstrap/cache/compiled.php(9408): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
27 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
28 symposium/bootstrap/cache/compiled.php(9390): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
29 symposium/bootstrap/cache/compiled.php(8755): Illuminate\Pipeline\Pipeline->then(Object(Closure))
30 symposium/bootstrap/cache/compiled.php(8740): Illuminate\Routing\ControllerDispatcher->callWithinStack(Object(Symposium\Http\Controllers\AccountController), Object(Illuminate\Routing\Route), Object(Illuminate\Http\Request), 'store')
31 symposium/bootstrap/cache/compiled.php(7717): Illuminate\Routing\ControllerDispatcher->dispatch(Object(Illuminate\Routing\Route), Object(Illuminate\Http\Request), 'Symposium\\Http\\...', 'store')
32 symposium/bootstrap/cache/compiled.php(7688): Illuminate\Routing\Route->runWithCustomDispatcher(Object(Illuminate\Http\Request))
33 symposium/bootstrap/cache/compiled.php(7342): Illuminate\Routing\Route->run(Object(Illuminate\Http\Request))
34 [internal function]: Illuminate\Routing\Router->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
35 symposium/bootstrap/cache/compiled.php(9408): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
36 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
37 symposium/bootstrap/cache/compiled.php(9390): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
38 symposium/bootstrap/cache/compiled.php(7343): Illuminate\Pipeline\Pipeline->then(Object(Closure))
39 symposium/bootstrap/cache/compiled.php(7331): Illuminate\Routing\Router->runRouteWithinStack(Object(Illuminate\Routing\Route), Object(Illuminate\Http\Request))
40 symposium/bootstrap/cache/compiled.php(7316): Illuminate\Routing\Router->dispatchToRoute(Object(Illuminate\Http\Request))
41 symposium/bootstrap/cache/compiled.php(2052): Illuminate\Routing\Router->dispatch(Object(Illuminate\Http\Request))
42 [internal function]: Illuminate\Foundation\Http\Kernel->Illuminate\Foundation\Http\{closure}(Object(Illuminate\Http\Request))
43 symposium/bootstrap/cache/compiled.php(9408): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
44 symposium/vendor/lucadegasperi/oauth2-server-laravel/src/Middleware/OAuthExceptionHandlerMiddleware.php(19): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
45 [internal function]: LucaDegasperi\OAuth2Server\Middleware\OAuthExceptionHandlerMiddleware->handle(Object(Illuminate\Http\Request), Object(Closure))
46 symposium/bootstrap/cache/compiled.php(9400): call_user_func_array(Array, Array)
47 symposium/bootstrap/cache/compiled.php(12644): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
48 [internal function]: Illuminate\View\Middleware\ShareErrorsFromSession->handle(Object(Illuminate\Http\Request), Object(Closure))
49 symposium/bootstrap/cache/compiled.php(9400): call_user_func_array(Array, Array)
50 symposium/bootstrap/cache/compiled.php(11296): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
51 [internal function]: Illuminate\Session\Middleware\StartSession->handle(Object(Illuminate\Http\Request), Object(Closure))
52 symposium/bootstrap/cache/compiled.php(9400): call_user_func_array(Array, Array)
53 symposium/bootstrap/cache/compiled.php(12382): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
54 [internal function]: Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse->handle(Object(Illuminate\Http\Request), Object(Closure))
55 symposium/bootstrap/cache/compiled.php(9400): call_user_func_array(Array, Array)
56 symposium/bootstrap/cache/compiled.php(12321): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
57 [internal function]: Illuminate\Cookie\Middleware\EncryptCookies->handle(Object(Illuminate\Http\Request), Object(Closure))
58 symposium/bootstrap/cache/compiled.php(9400): call_user_func_array(Array, Array)
59 symposium/bootstrap/cache/compiled.php(2659): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
60 [internal function]: Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode->handle(Object(Illuminate\Http\Request), Object(Closure))
61 symposium/bootstrap/cache/compiled.php(9400): call_user_func_array(Array, Array)
62 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
63 symposium/bootstrap/cache/compiled.php(9390): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
64 symposium/bootstrap/cache/compiled.php(1999): Illuminate\Pipeline\Pipeline->then(Object(Closure))
65 symposium/bootstrap/cache/compiled.php(1985): Illuminate\Foundation\Http\Kernel->sendRequestThroughRouter(Object(Illuminate\Http\Request))
66 symposium/public/index.php(53): Illuminate\Foundation\Http\Kernel->handle(Object(Illuminate\Http\Request))
67 {main}
```