### PR TITLE
Add storage/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 .sass-cache/
 /.idea
+/storage


### PR DESCRIPTION
This change prevents files under the `storage/` directory, such as
log files and SQLite database files, from appearing in git status
output.