### PR TITLE
Add database.sqlite to storage/.gitignore

### DIFF
--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,1 +1,2 @@
 laravel.log
+database.sqlite


### PR DESCRIPTION
This change is primarily intended to reduce potential friction
with new contributors by preventing accidental inclusion of
database.sqlite in commits.

Supersedes #133.