### PR TITLE
Redirect failed auth attempt to /log-in.

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -17,7 +17,8 @@ class AuthController extends BaseController
             return redirect()->intended('/dashboard');
         }
 
-        return back()->withErrors(['auth' => ['The email or password you entered is incorrect.']]);
+        return redirect()->route('log-in')
+            ->withErrors(['auth' => ['The email or password you entered is incorrect.']]);
     }
 
     public function logout()


### PR DESCRIPTION
Closes #137 

On a failed log in attempt, the user will be routed to /log-in (even from front page) and the error message will display in the appropriate place.