### PR TITLE
Delete account and relationships. 

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -94,10 +94,12 @@ class AccountController extends BaseController
 
     public function destroy()
     {
-        $user = Auth::user()->id;
-        $user->delete();
+        $userId = Auth::user()->id;
+        $user = User::find($userId);
 
         Auth::logout();
+
+        $user->delete();
 
         Session::flash('message', 'Successfully deleted account.');
 

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -94,11 +94,9 @@ class AccountController extends BaseController
 
     public function destroy()
     {
-        $userId = Auth::user()->id;
-        $user = User::find($userId);
+        $user = Auth::user();
 
         Auth::logout();
-
         $user->delete();
 
         Session::flash('message', 'Successfully deleted account.');

--- a/database/migrations/2016_02_13_144815_cascade_user_relationships.php
+++ b/database/migrations/2016_02_13_144815_cascade_user_relationships.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CascadeUserRelationships extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('talks', function(Blueprint $table) {
+            $table->dropForeign('talks_author_id_foreign');
+            $table->foreign('author_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('cascade');
+        });
+
+        Schema::table('bios', function(Blueprint $table) {
+            $table->dropForeign('bios_user_id_foreign');
+            $table->foreign('user_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('cascade');
+        });
+
+        Schema::table('conferences', function(Blueprint $table) {
+            $table->dropForeign('conferences_author_id_foreign');
+            $table->foreign('author_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Laracasts\TestDummy\Factory;
+
+class AccountTest extends IntegrationTestCase
+{
+    /**
+     * @test
+     */
+    public function it_deletes_the_user_account()
+    {
+        $user = Factory::create('user');
+        $this->actingAs($user)
+             ->visit('account/delete')
+             ->press('Yes')
+             ->seePageIs('/')
+             ->see('Successfully deleted account.');
+
+        $this->dontSeeInDatabase('users', [
+            'email' => $user->email,
+        ]);
+    }
+}

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -46,7 +46,7 @@ class AccountTest extends IntegrationTestCase
 
         $this->dontSeeInDatabase('talks', [
             'id' => $talk->id,
-            'author_id' => $talk->author_id,
+            'author_id' => $user->id,
             'public' => $talk->public,
         ]);
 

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -4,12 +4,10 @@ use Laracasts\TestDummy\Factory;
 
 class AccountTest extends IntegrationTestCase
 {
-    /**
-     * @test
-     */
-    public function it_deletes_the_user_account()
+    public function test_it_deletes_the_user_account()
     {
         $user = Factory::create('user');
+
         $this->actingAs($user)
              ->visit('account/delete')
              ->press('Yes')
@@ -18,6 +16,64 @@ class AccountTest extends IntegrationTestCase
 
         $this->dontSeeInDatabase('users', [
             'email' => $user->email,
+        ]);
+    }
+
+    public function test_it_deletes_users_associated_entities()
+    {
+        $user = Factory::create('user');
+        $talk = Factory::build('talk');
+        $talkRevision = Factory::build('talkRevision');
+        $bio = Factory::build('bio');
+        $conference = Factory::build('conference');
+        $favoriteConference = Factory::build('conference');
+
+        $user->talks()->save($talk);
+        $talk->revisions()->save($talkRevision);
+        $user->bios()->save($bio);
+        $user->conferences()->save($conference);
+        $user->favoritedConferences()->save($favoriteConference);
+
+        $this->actingAs($user)
+             ->visit('account/delete')
+             ->press('Yes')
+             ->seePageIs('/')
+             ->see('Successfully deleted account.');
+
+        $this->dontSeeInDatabase('users', [
+            'email' => $user->email,
+        ]);
+
+        $this->dontSeeInDatabase('talks', [
+            'id' => $talk->id,
+            'author_id' => $talk->author_id,
+            'public' => $talk->public,
+        ]);
+
+        $this->dontSeeInDatabase('bios', [
+            'id' => $bio->id,
+            'nickname' => $bio->nickname,
+            'body' => $bio->body,
+            'user_id' => $user->id,
+            'public' => $bio->public,
+        ]);
+
+        $this->dontSeeInDatabase('conferences', [
+            'id' => $conference->id,
+            'title' => $conference->title,
+            'description' => $conference->description,
+            'url' => $conference->url,
+            'author_id' => $user->id,
+            'starts_at' => $conference->starts_at->format('D M j, Y'),
+            'ends_at' => $conference->ends_at->format('D M j, Y'),
+            'cfp_starts_at' => $conference->cfp_starts_at->toFormattedDateString(),
+            'cfp_ends_at' => $conference->cfp_ends_at->toFormattedDateString(),
+            'joindin_id' => $conference->joindin_id,
+        ]);
+
+        $this->dontSeeInDatabase('favorites', [
+            'user_id' => $user->id,
+            'conference_id' => $conference->id,
         ]);
     }
 }


### PR DESCRIPTION
Solves #154 
- Migration adds cascade on delete constraints on user relationships. 
- Added a test that confirms the fix.