### PR TITLE
Bugfix: Update query to account for empty profile_slug

### DIFF
--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -22,6 +22,7 @@ class PublicProfileController extends Controller
     public function index()
     {
         $users = User::where('enable_profile', true)
+            ->whereNotNull('profile_slug')
             ->orderBy('name', 'asc')
             ->get();
 


### PR DESCRIPTION
This PR: 
- [x] adds a where clause to filter out speakers marked as public that have an empty `profile_slug`. 

On the `/speakers` list page if the `profile_slug` is null the link becomes invalid pointing to: `http://symposiumapp.com/u/`

This will filter out those speakers. Alternatively, there could be validation added here: https://github.com/tightenco/symposium/blob/master/app/Http/Controllers/AccountController.php#L79-L82 that would force a slug to be set when `enable_profile` is true. 