### PR TITLE
Bugfix: Bug introduced in aa59503a returning associative array

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -30,7 +30,7 @@ class User extends Authenticatable
     {
         return $this->talks()->get()->sortBy(function ($talk) {
             return strtolower($talk->current()->title);
-        });
+        })->values();
     }
 
     public function bios()


### PR DESCRIPTION
Laravel's Illuminate\Support\Collection::sortBy() preserves the keys,
and therefore will always return an associative array, even when it
used to be sequential. If you json_encode the result, you might
expect an array, but get an object instead. This commit fixes that
issue, by discarding the array keys, and fetching only its values.
This fixes an issue with vue.js not being able to .forEach over an
object.