### PR TITLE
Allow conferences to be one day conferences

### DIFF
--- a/app/Services/CreateConferenceForm.php
+++ b/app/Services/CreateConferenceForm.php
@@ -13,7 +13,7 @@ class CreateConferenceForm
         'url' => ['required'],
         'cfp_url' => [],
         'starts_at' => ['date'],
-        'ends_at' => ['date', 'after:starts_at'],
+        'ends_at' => ['date', 'onOrAfter:starts_at'],
         'cfp_starts_at' => ['date', 'before:starts_at'],
         'cfp_ends_at' => ['date', 'after:cfp_starts_at', 'before:starts_at'],
     ];

--- a/app/Validators/OnOrAfterValidator.php
+++ b/app/Validators/OnOrAfterValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Validators;
+
+use Illuminate\Validation\Validator;
+
+class OnOrAfterValidator
+{
+    /**
+     * Validate if the date is the same, or after another date
+     *
+     * @param           $attribute
+     * @param           $value
+     * @param           $parameters
+     * @param Validator $validator
+     *
+     * @return bool
+     */
+    public function validate($attribute, $value, array $parameters, Validator $validator)
+    {
+        if (! is_string($value) && ! is_numeric($value) && ! $value instanceof DateTimeInterface) {
+            return false;
+        }
+
+        $data = $validator->getData();
+        if (empty($parameters[0]) || empty($data[$parameters[0]])) {
+            return false;
+        }
+        $date = $this->getDateTimestamp($data[$parameters[0]]);
+
+        return $this->getDateTimestamp($value) >= $date;
+    }
+
+    /**
+     * Get the date timestamp.
+     *
+     * @param  mixed  $value
+     * @return int
+     */
+    protected function getDateTimestamp($value)
+    {
+        return $value instanceof DateTimeInterface ? $value->getTimestamp() : strtotime($value);
+    }
+
+    /**
+     * Generate message to display to the user on validation fail
+     *
+     * @param $message
+     * @param $attribute
+     * @param $rule
+     * @param $parameters
+     *
+     * @return mixed
+     */
+    public function message($message, $attribute, $rule, array $parameters)
+    {
+        return str_replace('_', ' ', 'The '.$attribute.' must be a date on or after '.$parameters[0]);
+    }
+}

--- a/app/macros.php
+++ b/app/macros.php
@@ -31,3 +31,6 @@ Response::macro('jsonApi', function ($value) {
     $response->headers->set('Content-Type', 'application/vnd.api+json');
     return $response;
 });
+
+Validator::extend('onOrAfter', 'App\Validators\OnOrAfterValidator@validate');
+Validator::replacer('onOrAfter', 'App\Validators\OnOrAfterValidator@message');

--- a/tests/CreateConferenceFormTest.php
+++ b/tests/CreateConferenceFormTest.php
@@ -105,6 +105,24 @@ class CreateConferenceFormTest extends IntegrationTestCase
 
     /**
      * @test
+     */
+    public function conference_can_be_a_single_day_conference()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+            'starts_at' => '2015-02-04',
+            'ends_at' => '2015-02-04',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+        // No assertions, as it should throw an exception on error.
+    }
+
+    /**
+     * @test
      * @expectedException App\Exceptions\ValidationException
      */
     public function conference_cfp_start_date_must_be_a_valid_date()


### PR DESCRIPTION
The conference ends_at and starts_at should be allowed to be the same day. Laravel's Validator class currently doesn't support this, so the validator was extended to add a 'onOrAfter' validation rule.
