### PR TITLE
Hide underline for public profile pic link

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -374,6 +374,10 @@ legend {
     img {
         border-radius: 50%;
     }
+    
+    a {
+        text-decoration: none;
+    }
 
     @media only screen and (min-width: 768px) {
         float: right;


### PR DESCRIPTION
The underline was showing a single character after the image on hover. This removes the underline. See Image:

![image](https://cloud.githubusercontent.com/assets/1248035/22157677/a47064a4-df06-11e6-9c15-070fec47a755.png)

P.S. - I'm a little OCD...