### PR TITLE
Test JoindIn conference importer and fix null date issue

### DIFF
--- a/app/JoindIn/ConferenceImporter.php
+++ b/app/JoindIn/ConferenceImporter.php
@@ -15,7 +15,7 @@ class ConferenceImporter
 
     public function __construct($authorId = null)
     {
-        $this->client = JoindInClient::factory();
+        $this->client = app(JoindInClient::class);
         $this->authorId = $authorId ?: auth()->user()->id;
     }
 
@@ -56,8 +56,8 @@ class ConferenceImporter
 
     private function carbonFromIso($dateFromApi)
     {
-        if ($dateFromApi == null) {
-            return Carbon::create(null);
+        if (! $dateFromApi) {
+            return null;
         }
 
         return Carbon::createFromFormat(DateTime::ISO8601, $dateFromApi);

--- a/app/Providers/JoindInServiceProvider.php
+++ b/app/Providers/JoindInServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use JoindIn\Client;
+
+class JoindInServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->bind(Client::class, function ($app) {
+            return Client::factory();
+        });
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "type": "project",
     "require": {
         "laravel/framework": "5.3.*",
-        "rexxars/joindin-client": "dev-master",
+        "rexxars/joindin-client": "^0.0.1",
         "guzzlehttp/guzzle": "~5.3|~6.0",
         "laravelcollective/html": "5.3.*",
         "doctrine/dbal": "~2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "18156798e0a2fe2dc1a0b9edf2352e2e",
-    "content-hash": "b2025b0dfbeff351aef4d066d527e53b",
+    "hash": "e341958e67efacfc6d7d1baccc09f204",
+    "content-hash": "87932e6b6d34122aaa378d2ce2443b54",
     "packages": [
         {
             "name": "bugsnag/bugsnag",
@@ -2446,11 +2446,11 @@
         },
         {
             "name": "rexxars/joindin-client",
-            "version": "dev-master",
+            "version": "0.0.1",
             "source": {
                 "type": "git",
                 "url": "git@github.com:mattstauffer/joindin-client.git",
-                "reference": "7508830f787125218e80b93d39d8a1e54d290130"
+                "reference": "42f0a991bf4ae33676d32d00a70c8459f7a71374"
             },
             "require": {
                 "guzzle/guzzle": "3.7.1",
@@ -5280,7 +5280,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "rexxars/joindin-client": 20,
         "thomaswelton/laravel-gravatar": 20,
         "thujohn/twitter": 20
     },

--- a/config/app.php
+++ b/config/app.php
@@ -171,6 +171,7 @@ return [
 
         'App\Providers\OAuthGuardServiceProvider',
         App\Providers\CaptchaServiceProvider::class,
+        App\Providers\JoindInServiceProvider::class,
         Intervention\Image\ImageServiceProvider::class,
     ],
 

--- a/tests/JoindInConferenceImporterTest.php
+++ b/tests/JoindInConferenceImporterTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use App\Conference;
+use App\JoindIn\ConferenceImporter;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use JoindIn\Client;
+use Mockery as m;
+
+class JoindInConferenceImporterTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    private $eventStub = [
+        'id' => 12345,
+        'name' => 'ABC conference',
+        'description' => 'The greatest conference ever.',
+        'website_uri' => 'http://abccon.com/',
+        'cfp_url' => 'http://cfp.abccon.com/',
+        "cfp_start_date" => "2017-08-20T00:00:00-04:00",
+        "cfp_end_date" => "2017-09-22T00:00:00-04:00",
+        "start_date" => "2017-10-20T00:00:00-04:00",
+        "end_date" => "2017-12-22T00:00:00-04:00",
+    ];
+
+    function mockClient($event = null)
+    {
+        if (! $event) {
+            $event = $this->eventStub;
+        }
+
+        $mockClient = m::mock(Client::class);
+
+        $mockClient->shouldReceive('getEvent')->andReturn([$event]);
+        app()->instance(Client::class, $mockClient);
+
+        return $mockClient;
+    }
+
+    /** @test */
+    function it_imports_basic_text_fields()
+    {
+        $this->mockClient();
+
+        $importer = new ConferenceImporter(1);
+        $importer->import($this->eventStub['id']);
+
+        $this->assertEquals(1, Conference::count());
+        $conference = Conference::first();
+
+        $this->assertEquals($this->eventStub['name'], $conference->title);
+        $this->assertEquals($this->eventStub['description'], $conference->description);
+        $this->assertEquals($this->eventStub['id'], $conference->joindin_id);
+        $this->assertEquals($this->eventStub['cfp_url'], $conference->cfp_url);
+    }
+
+    /** @test */
+    function it_imports_dates_if_we_dont_care_about_time_zones()
+    {
+        $event = $this->eventStub;
+
+        $event["cfp_start_date"] = "2017-01-20T00:00:00+00:00";
+        $event["cfp_end_date"] = "2017-02-22T00:00:00+00:00";
+        $event["start_date"] = "2017-03-20T00:00:00+00:00";
+        $event["end_date"] = "2017-04-22T00:00:00+00:00";
+
+        $this->mockClient($event);
+
+        $importer = new ConferenceImporter(1);
+        $importer->import($this->eventStub['id']);
+
+        $conference = Conference::first();
+
+        /**
+         * Problem here: Our importer discards the time zone when it saves
+         * it to the database. So we have to decide: Do we add time zone?
+         * Do we convert to UTC? But nothing else in the app is in UTC; we just
+         * let it all live in non-existent time zone, the user's sort of
+         * intended time zone, I guess.
+         *
+         * That makes this test fail if it's written correctly--because it saves
+         * the *time* but returns it in the wrong time zone.
+         *
+         * Right now, let's just say that, assuming the way it handles dates
+         * right now, we at least want to make sure the strong is stored
+         * correctly. Because of time zones and daylight savings time, the
+         * easiest option is this piece of hideousness.
+         */
+        $this->assertEquals(
+            substr($event['cfp_start_date'], 0, 19),
+            substr($conference->cfp_starts_at->toIso8601String(), 0, 19)
+        );
+        $this->assertEquals(
+            substr($event['cfp_end_date'], 0, 19),
+            substr($conference->cfp_ends_at->toIso8601String(), 0, 19)
+        );
+        $this->assertEquals(
+            substr($event['start_date'], 0, 19),
+            substr($conference->starts_at->toIso8601String(), 0, 19)
+        );
+        $this->assertEquals(
+            substr($event['end_date'], 0, 19),
+            substr($conference->ends_at->toIso8601String(), 0, 19)
+        );
+    }
+
+    /** @test */
+    function it_imports_dates_with_the_correct_time_zone()
+    {
+        $this->markTestIncomplete('Time zones are hard.');
+
+        $this->mockClient();
+
+        $importer = new ConferenceImporter(1);
+        $importer->import($this->eventStub['id']);
+
+        $conference = Conference::first();
+
+        // $this->assertEquals($this->eventStub['cfp_start_date'], $conference->cfp_starts_at->toIso8601String());
+        // $this->assertEquals($this->eventStub['cfp_end_date'], $conference->cfp_ends_at->toIso8601String());
+        // $this->assertEquals($this->eventStub['start_date'], $conference->starts_at->toIso8601String());
+        // $this->assertEquals($this->eventStub['end_date'], $conference->ends_at->toIso8601String());
+    }
+
+    /** @test */
+    function it_imports_null_dates_as_null()
+    {
+        $event = $this->eventStub;
+
+        $event['cfp_end_date'] = null;
+
+        $this->mockClient($event);
+
+        $importer = new ConferenceImporter(1);
+        $importer->import($this->eventStub['id']);
+
+        $conference = Conference::first();
+
+        $this->assertNull($conference->cfp_ends_at);
+    }
+}


### PR DESCRIPTION
Original issue:

https://twitter.com/rawkode/status/876412992556085249

If we were getting null dates back from Joind.In, it would update the date every day the sync ran, meaning MANY tweets with the same information.

![image](https://user-images.githubusercontent.com/151829/27262471-903c9d2e-5425-11e7-8a77-a27447f10097.png)
