### PR TITLE
Add passport information to installation guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,14 +25,27 @@ A fun side project by some lovely folks at [Tighten Co.](http://tighten.co/).
 2. Clone the repository locally
 3. [Install dependencies](https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies) with `composer install`
 4. Copy [`.env.example`](https://github.com/tightenco/symposium/blob/master/.env.example) to `.env` and modify its contents to reflect your local environment.
-5. [Run database migrations](http://laravel.com/docs/5.1/migrations#running-migrations). If you want to include seed data, add a `--seed` flag.
+5. Generate an application key 
+
+    ```bash 
+    php artisan key:generate
+    ```
+    
+6. [Run database migrations](http://laravel.com/docs/5.1/migrations#running-migrations). If you want to include seed data, add a `--seed` flag.
 
     ```bash
     php artisan migrate --env=local
     ```
-6. Configure a web server, such as the [built-in PHP web server](http://php.net/manual/en/features.commandline.webserver.php), to use the `public` directory as the document root.
+    
+7. (Optionally) Enable the API. This will output two client ID/secrets that you can use for testing
+
+    ```bash
+    php artisan passport:install
+    ```
+    
+8. Configure a web server, such as the [built-in PHP web server](http://php.net/manual/en/features.commandline.webserver.php), to use the `public` directory as the document root.
 
     ```bash
     php -S localhost:8080 -t public
     ```
-7. Run tests with `composer test`.
+9. Run tests with `composer test`.


### PR DESCRIPTION
Whilst debugging an issue with Pronto I couldn't find any information on how to enable the API and create a client ID. This PR adds minimal instruction to the README