### PR TITLE
Fix Oauth Routing

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -89,28 +89,6 @@ Route::group(['middleware' => 'auth'], function () {
 Route::get('conferences', ['as' => 'conferences.index', 'uses' => 'ConferencesController@index']);
 Route::get('conferences/{id}', ['as' => 'conferences.show', 'uses' => 'ConferencesController@show']);
 
-/**
- * OAuth
- */
-Route::group(['middleware' => 'auth'], function () {
-    Route::get('oauth/authorize', [
-        'middleware' => ['check-authorization-params', 'auth'],
-        'as' => 'get-oauth-authorize',
-        'uses' => 'OAuthController@getAuthorize'
-    ]);
-
-    Route::post('oauth/authorize', [
-        'middleware' => ['check-authorization-params', 'auth'],
-        'as' => 'post-oauth-authorize',
-        'uses' => 'OAuthController@postAuthorize'
-    ]);
-});
-
-Route::post('oauth/access-token', [
-    'as' => 'oauth-access-token',
-    'uses' => 'OAuthController@postAccessToken'
-]);
-
 // Social logins routes
 Route::group(['middleware' => ['social', 'guest']], function () {
     Route::get('/login/{service}', 'Auth\SocialLoginController@redirect');


### PR DESCRIPTION
During the installation of Passport to be the new Oauth/Api provider,
the Oauth routes were removed (https://github.com/tightenco/symposium/commit/62119f19e0035f5b76630621757d360fed99bff2#diff-7e3ce459dfcc113722bdf4667ceffc11L87)

However in what looks like a bad merge they were re-added during the
install of social login, but they now point to an missing
OAuthController (https://github.com/tightenco/symposium/commit/9b1ecb6186bb77cf2744e90c09d75e3e21edf617#diff-7e3ce459dfcc113722bdf4667ceffc11R91)

This commit removes these routes once more.