### PR TITLE
Add github to login view

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -10,6 +10,11 @@
                     </div>
                     <div class="panel-body">
                         {!! $errors->first('auth', '<div class="alert alert-danger">:message</div>') !!}
+                        <div class="text-center">
+                            <a class="btn-auth btn-github large" href="{{ url('login/github') }}">Sign in with <strong>GitHub</strong></a>
+                            <br>
+                            <p class="text-muted">or</p>
+                        </div>
                         @include ('partials.log-in-form')
                     </div>
                 </div>


### PR DESCRIPTION
I noticed that the "Sign in with GitHub" option was missing from the "Login" page, which was really confusing.