### PR TITLE
Stop compiled js/css from being committed during development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .env
 .sass-cache/
 /storage/*.key
+/public/css
+/public/js


### PR DESCRIPTION
When I run `npm run dev` while developing it changes these files. Since those files are compiled during deployment I thought it would be a good idea to stop changes from happening in these directories. 