### PR TITLE
Am feature/summary cfp email and default to page link

### DIFF
--- a/app/Console/Commands/SendNotificationForOpenCFPs.php
+++ b/app/Console/Commands/SendNotificationForOpenCFPs.php
@@ -31,16 +31,19 @@ class SendNotificationForOpenCFPs extends Command
      */
     public function handle()
     {
-        $conferences = Conference::approved()->notShared()->openCFP()->get();
+        $conferences = $this->conferencesToShare()->get();
 
         if ($conferences->isEmpty()) {
             return;
         }
 
-        $conferences->each(function ($conference) {
-            $conference->update(['is_shared' => true]);
-        });
+        $this->conferencesToShare()->update(['is_shared' => true]);
 
         Notification::send(User::wantsNotifications()->get(), new CFPsAreOpen($conferences));
+    }
+
+    protected function conferencesToShare()
+    {
+        return Conference::approved()->notShared()->openCFP();
     }
 }

--- a/app/Console/Commands/SendNotificationForOpenCFPs.php
+++ b/app/Console/Commands/SendNotificationForOpenCFPs.php
@@ -2,10 +2,10 @@
 
 namespace App\Console\Commands;
 
-use App\User;
 use App\Conference;
-use Illuminate\Console\Command;
 use App\Notifications\CFPsAreOpen;
+use App\User;
+use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Notification;
 
 class SendNotificationForOpenCFPs extends Command

--- a/app/Console/Commands/SendNotificationForOpenCFPs.php
+++ b/app/Console/Commands/SendNotificationForOpenCFPs.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use App\User;
 use App\Conference;
 use Illuminate\Console\Command;
-use App\Notifications\CFPIsOpen;
+use App\Notifications\CFPsAreOpen;
 use Illuminate\Support\Facades\Notification;
 
 class SendNotificationForOpenCFPs extends Command
@@ -31,10 +31,16 @@ class SendNotificationForOpenCFPs extends Command
      */
     public function handle()
     {
-        Conference::approved()->notShared()->openCFP()->each(function ($conference) {
-            $conference->update(['is_shared' => true]);
+        $conferences = Conference::approved()->notShared()->openCFP()->get();
 
-            Notification::send(User::wantsNotifications()->get(), new CFPIsOpen($conference));
+        if ($conferences->isEmpty()) {
+            return;
+        }
+
+        $conferences->each(function ($conference) {
+            $conference->update(['is_shared' => true]);
         });
+
+        Notification::send(User::wantsNotifications()->get(), new CFPsAreOpen($conferences));
     }
 }

--- a/app/Listeners/SendNotificationForOpenCFPs.php
+++ b/app/Listeners/SendNotificationForOpenCFPs.php
@@ -3,7 +3,7 @@
 namespace App\Listeners;
 
 use App\Events\ConferenceCreated;
-use App\Notifications\CFPIsOpen;
+use App\Notifications\CFPsAreOpen;
 use App\User;
 use Illuminate\Support\Facades\Notification;
 
@@ -24,7 +24,7 @@ class SendNotificationForOpenCFPs
             && !$conference->is_shared) {
             $conference->update(['is_shared' => true]);
 
-            Notification::send(User::wantsNotifications()->get(), new CFPIsOpen($conference));
+            Notification::send(User::wantsNotifications()->get(), new CFPsAreOpen(collect([$conference])));
         }
     }
 }

--- a/app/Notifications/CFPsAreOpen.php
+++ b/app/Notifications/CFPsAreOpen.php
@@ -19,9 +19,9 @@ class CFPsAreOpen extends Notification
     /**
      * Create a new notification instance.
      *
-     * @param Conference $conference
+     * @param $conferences an array or collection of conferences
      */
-    public function __construct(Collection $conferences)
+    public function __construct($conferences)
     {
         $this->conferences = $conferences;
     }

--- a/app/Notifications/CFPsAreOpen.php
+++ b/app/Notifications/CFPsAreOpen.php
@@ -11,9 +11,6 @@ class CFPsAreOpen extends Notification
 {
     use Queueable;
 
-    /**
-     * @var Conferences
-     */
     public $conferences;
 
     /**

--- a/app/Notifications/CFPsAreOpen.php
+++ b/app/Notifications/CFPsAreOpen.php
@@ -12,7 +12,7 @@ class CFPsAreOpen extends Notification
     use Queueable;
 
     /**
-     * @var Conference
+     * @var Conferences
      */
     public $conferences;
 

--- a/app/Notifications/CFPsAreOpen.php
+++ b/app/Notifications/CFPsAreOpen.php
@@ -2,28 +2,28 @@
 
 namespace App\Notifications;
 
-use App\Conference;
 use Illuminate\Bus\Queueable;
+use Illuminate\Support\Collection;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\MailMessage;
 
-class CFPIsOpen extends Notification
+class CFPsAreOpen extends Notification
 {
     use Queueable;
 
     /**
      * @var Conference
      */
-    public $conference;
+    public $conferences;
 
     /**
      * Create a new notification instance.
      *
      * @param Conference $conference
      */
-    public function __construct(Conference $conference)
+    public function __construct(Collection $conferences)
     {
-        $this->conference = $conference;
+        $this->conferences = $conferences;
     }
 
     /**
@@ -46,8 +46,9 @@ class CFPIsOpen extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->subject('New Open CFP')
-            ->line('The CFP for '.$this->conference->title.' is now open.')
-            ->action('Visit CFP', $this->conference->cfp_url);
+            ->subject('New Open CFPs')
+            ->markdown('emails.open-cfps', [
+                'conferences' => $this->conferences
+            ]);
     }
 }

--- a/app/Notifications/CFPsAreOpen.php
+++ b/app/Notifications/CFPsAreOpen.php
@@ -3,9 +3,9 @@
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Support\Collection;
-use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
 
 class CFPsAreOpen extends Notification
 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
         <env name="DB_CONNECTION" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
+        <env name="SCOUT_DRIVER" value="null"/>
         <env name="CAPTCHA_PUBLIC" value="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"/>
         <env name="CAPTCHA_PRIVATE" value="6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"/>
     </php>

--- a/resources/views/emails/open-cfps.blade.php
+++ b/resources/views/emails/open-cfps.blade.php
@@ -1,0 +1,7 @@
+@component('mail::message')
+The following CFPs are now open:
+
+@foreach($conferences as $conference)
+- [{{ $conference->title }}]({{ $conference->cfp_url ?: $conference->url }})
+@endforeach
+@endcomponent

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use App\Conference;
-use App\Events\ConferenceCreated;
-use App\Listeners\SendNotificationForOpenCFPs;
-use App\Notifications\CFPIsOpen;
 use App\User;
 use Carbon\Carbon;
+use App\Conference;
+use App\Events\ConferenceCreated;
+use App\Notifications\CFPsAreOpen;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Notification;
+use App\Listeners\SendNotificationForOpenCFPs;
 
 class NotificationTest extends IntegrationTestCase
 {
@@ -22,13 +22,8 @@ class NotificationTest extends IntegrationTestCase
 
         event(new ConferenceCreated($conference));
 
-        $conference = Conference::first();
-
-        Notification::assertSentTo($user, CFPIsOpen::class, function ($notification) use ($conference) {
-            return $notification->conference->id === $conference->id;
-        });
-
-        $this->assertTrue(Conference::first()->is_shared);
+        $this->assertUserNotifiedOfCfp($user, $conference);
+        $this->assertTrue($conference->is_shared);
     }
 
     /** @test */
@@ -40,7 +35,7 @@ class NotificationTest extends IntegrationTestCase
 
         event(new ConferenceCreated($conference));
 
-        Notification::assertNotSentTo($user, CFPIsOpen::class);
+        Notification::assertNotSentTo($user, CFPsAreOpen::class);
     }
 
     /** @test */
@@ -52,7 +47,7 @@ class NotificationTest extends IntegrationTestCase
 
         event(new ConferenceCreated($conference));
 
-        Notification::assertNotSentTo($user, CFPIsOpen::class);
+        Notification::assertNotSentTo($user, CFPsAreOpen::class);
     }
 
     /** @test */
@@ -71,22 +66,19 @@ class NotificationTest extends IntegrationTestCase
             ->type(Carbon::tomorrow()->toDateString(), '#cfp_ends_at')
             ->press('Create');
 
-        Notification::assertNotSentTo($user, CFPIsOpen::class);
+        Notification::assertNotSentTo($user, CFPsAreOpen::class);
     }
 
     /** @test */
     function command_will_trigger_notification_for_approved_and_not_shared_conference()
     {
         Notification::fake();
-        factory(App\User::class)->states('wantsNotifications')->create();
+        $user = factory(App\User::class)->states('wantsNotifications')->create();
         $conference = factory(Conference::class)->create(['is_approved' => true, 'is_shared' => false]);
 
         Artisan::call('symposium:notifyCfps');
 
-        Notification::assertSentTo(User::wantsNotifications()->get(), CFPIsOpen::class, function ($notification) use ($conference) {
-            return $notification->conference->id === $conference->id;
-        });
-
+        $this->assertUserNotifiedOfCfp($user, $conference);
         $this->assertTrue(Conference::first()->is_shared);
     }
 
@@ -99,7 +91,7 @@ class NotificationTest extends IntegrationTestCase
 
         Artisan::call('symposium:notifyCfps');
 
-        Notification::assertNotSentTo([$user], CFPIsOpen::class);
+        Notification::assertNotSentTo([$user], CFPsAreOpen::class);
     }
 
     /** @test */
@@ -114,7 +106,7 @@ class NotificationTest extends IntegrationTestCase
 
         Artisan::call('symposium:notifyCfps');
 
-        Notification::assertNotSentTo([$user], CFPIsOpen::class);
+        Notification::assertNotSentTo([$user], CFPsAreOpen::class);
     }
 
     /** @test */
@@ -126,7 +118,7 @@ class NotificationTest extends IntegrationTestCase
 
         Artisan::call('symposium:notifyCfps');
 
-        Notification::assertNotSentTo([$user], CFPIsOpen::class);
+        Notification::assertNotSentTo([$user], CFPsAreOpen::class);
     }
 
     /** @test */
@@ -138,6 +130,13 @@ class NotificationTest extends IntegrationTestCase
 
         Artisan::call('symposium:notifyCfps');
 
-        Notification::assertNotSentTo([$user], CFPIsOpen::class);
+        Notification::assertNotSentTo([$user], CFPsAreOpen::class);
+    }
+
+    private function assertUserNotifiedOfCfp($user, $conference)
+    {
+        Notification::assertSentTo($user, CFPsAreOpen::class, function ($notification) use ($conference) {
+            return $notification->conferences->pluck('id')->contains($conference->id);
+        });
     }
 }

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -1,13 +1,13 @@
 <?php
 
 use App\User;
-use Carbon\Carbon;
 use App\Conference;
 use App\Events\ConferenceCreated;
+use App\Listeners\SendNotificationForOpenCFPs;
 use App\Notifications\CFPsAreOpen;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Notification;
-use App\Listeners\SendNotificationForOpenCFPs;
 
 class NotificationTest extends IntegrationTestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,12 +12,6 @@ abstract class TestCase extends BaseTestCase
      */
     public $baseUrl = 'http://localhost';
 
-    public function setUp()
-    {
-        parent::setUp();
-        Config::set(['scout.driver' => null]);
-    }
-
     /**
      * Creates the application.
      *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,6 +12,12 @@ abstract class TestCase extends BaseTestCase
      */
     public $baseUrl = 'http://localhost';
 
+    public function setUp()
+    {
+        parent::setUp();
+        Config::set(['scout.driver' => null]);
+    }
+
     /**
      * Creates the application.
      *


### PR DESCRIPTION
This PR does two things:

1. Tests are now run without connecting to Algolia, which gives a bit of a speed increase.
2. When the `symposium:notifyCfps` command is run, if there are multiple conferences with open CFPs, they will be listed in one email instead of sending an email for each one.