### PR TITLE
Update Installation section in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ A fun side project by some lovely folks at [Tighten Co.](http://tighten.co/).
 * PHP >= 5.5.9
 * A [supported relational database](http://laravel.com/docs/5.1/database#introduction) and corresponding PHP extension
 * [Composer](https://getcomposer.org/download/)
+* [NPM](https://nodejs.org/)
 * [Google Places API Key](https://developers.google.com/places/web-service/get-api-key) for speakers to set their location. A configuration guide can be found [here](/google-guide.md).
 * [Algolia](https://www.algolia.com/) Account
 
@@ -24,24 +25,24 @@ A fun side project by some lovely folks at [Tighten Co.](http://tighten.co/).
 2. Clone the repository locally
 3. [Install dependencies](https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies) with `composer install`
 4. Copy [`.env.example`](https://github.com/tightenco/symposium/blob/master/.env.example) to `.env` and modify its contents to reflect your local environment.
-5. Generate an application key 
-
-    ```bash 
-    php artisan key:generate
-    ```
-    
-6. [Run database migrations](http://laravel.com/docs/5.1/migrations#running-migrations). If you want to include seed data, add a `--seed` flag.
-
-    ```bash
-    php artisan migrate --env=local
-    ```
-    
-7. Place your Algolia keys in the `.env` file. This is also required for running PHPUnit tests.
+5. Place your Algolia keys in the `.env` file. This is also required for running PHPUnit tests.
 	
 	```bash
 	ALGOLIA_APP_ID=your-app-id-key
 	ALGOLIA_SECRET=your-secret-key
 	```
+    
+6. Generate an application key 
+
+    ```bash 
+    php artisan key:generate
+    ```
+    
+7. [Run database migrations](http://laravel.com/docs/5.1/migrations#running-migrations). If you want to include seed data, add a `--seed` flag.
+
+    ```bash
+    php artisan migrate --env=local
+    ```
     
 8. (Optionally) Enable the API. This will output two client ID/secrets that you can use for testing
 
@@ -49,9 +50,11 @@ A fun side project by some lovely folks at [Tighten Co.](http://tighten.co/).
     php artisan passport:install
     ```
     
-9. Configure a web server, such as the [built-in PHP web server](http://php.net/manual/en/features.commandline.webserver.php), to use the `public` directory as the document root.
+9. [Install frontend dependencies](https://docs.npmjs.com/cli/install) with `npm install`
+10. Build CSS with `npm run dev`
+11. Configure a web server, such as the [built-in PHP web server](http://php.net/manual/en/features.commandline.webserver.php), to use the `public` directory as the document root.
 
     ```bash
     php -S localhost:8080 -t public
     ```
-10. Run tests with `composer test`.
+12. Run tests with `composer test`.


### PR DESCRIPTION
1. Move the Algolia key section immediately after the `.env` step.  A key is necessary to run `php artisan migrate --env=local --seed` for the first time 🤷🏻‍♂️.  Not sure if a key is necessary to run the migrations without seed data, but in any case it's helpful to have that step first (though a hard dependency on Algolia isn't ideal).
2. Add steps to install frontend dependencies and generate CSS.  The site "works" but looks unpretty without this step.