### PR TITLE
Add a Try Catch to the JoindIn Client Call

### DIFF
--- a/app/Console/Commands/SyncJoindInEvents.php
+++ b/app/Console/Commands/SyncJoindInEvents.php
@@ -2,17 +2,17 @@
 
 namespace App\Console\Commands;
 
+use App\JoindIn\ConferenceImporter;
+use Exception;
 use Illuminate\Console\Command;
 use JoindIn\Client as JoindInClient;
-use App\JoindIn\ConferenceImporter;
 
 class SyncJoindInEvents extends Command
 {
     protected $name = 'joindin:sync';
-
     protected $description = 'Sync down Joind.in events.';
-
     protected $client;
+
     private $importer;
 
     public function __construct()
@@ -30,11 +30,17 @@ class SyncJoindInEvents extends Command
     {
         $this->info('Syncing events...');
 
-        foreach ($this->client->getEvents() as $event) {
-            $this->info('Creating/updating event ' . $event['name']);
-            $this->importer->import($event['id']);
-        }
+        try {
+            $events = $this->client->getEvents();
 
-        $this->info('Events synced.');
+            foreach ($events as $event) {
+                $this->info('Creating/updating event ' . $event['name']);
+                $this->importer->import($event['id']);
+            }
+
+            $this->info('Events synced.');
+        } catch (Exception $exception) {
+            $this->error("Unable to sync Joind.in events. Message: {$exception->getMessage()}");
+        }
     }
 }

--- a/app/Console/Commands/SyncJoindInEvents.php
+++ b/app/Console/Commands/SyncJoindInEvents.php
@@ -32,15 +32,16 @@ class SyncJoindInEvents extends Command
 
         try {
             $events = $this->client->getEvents();
-
-            foreach ($events as $event) {
-                $this->info('Creating/updating event ' . $event['name']);
-                $this->importer->import($event['id']);
-            }
-
-            $this->info('Events synced.');
         } catch (Exception $exception) {
             $this->error("Unable to sync Joind.in events. Message: {$exception->getMessage()}");
+            return;
         }
+
+        foreach ($events as $event) {
+            $this->info('Creating/updating event ' . $event['name']);
+            $this->importer->import($event['id']);
+        }
+
+        $this->info('Events synced.');
     }
 }


### PR DESCRIPTION
Currently, if the Joind.in client call has a server error, we don't catch the exception. This adds the try/catch block.