### PR TITLE
Fix command for running tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover"
         ],
-        "test": "./vendor/bin/phpunit"
+        "test": "phpunit"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
Output for `composer test`:
```plain
> ./vendor/bin/phpunit
'.' is not recognized as an internal or external command,
operable program or batch file.
Script ./vendor/bin/phpunit handling the test event returned with error code 1
```

The `./` part is not necessary on any platform, and the `/` cause problems on Windows, and in any case, none are required due to Composer's [PATH handling](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands)