### PR TITLE
Add location field to Conference

### DIFF
--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -32,6 +32,7 @@ class ConferenceImporter
         $conference->description = trim($event->description);
         $conference->url = trim($event->eventUri);
         $conference->cfp_url = $event->uri;
+        $conference->location = $event->location;
         $conference->starts_at = self::carbonFromIso($event->dateEventStart);
         $conference->ends_at = self::carbonFromIso($event->dateEventEnd);
         $conference->cfp_starts_at = self::carbonFromIso($event->dateCfpStart);

--- a/app/Conference.php
+++ b/app/Conference.php
@@ -15,6 +15,7 @@ class Conference extends UuidBase
     protected $fillable = [
         'author_id',
         'title',
+        'location',
         'description',
         'url',
         'cfp_url',

--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -17,6 +17,7 @@ class ConferencesController extends BaseController
         'title' => ['required'],
         'description' => ['required'],
         'url' => ['required'],
+        'location' => [],
         'cfp_url' => [],
         'starts_at' => ['date'],
         'ends_at' => ['date', 'onOrAfter:starts_at'],
@@ -149,7 +150,7 @@ class ConferencesController extends BaseController
         }
 
         // Save
-        $conference->fill($request->all(['title', 'description', 'url', 'cfp_url']));
+        $conference->fill($request->all(['title', 'description', 'location', 'url', 'cfp_url']));
 
         foreach (['starts_at', 'ends_at', 'cfp_starts_at', 'cfp_ends_at'] as $col) {
             $conference->$col = $request->input($col) ?: null;

--- a/app/Services/CreateConferenceForm.php
+++ b/app/Services/CreateConferenceForm.php
@@ -15,6 +15,7 @@ class CreateConferenceForm
         'description' => ['required'],
         'url' => ['required'],
         'cfp_url' => [],
+        'location' => [],
         'starts_at' => ['date'],
         'ends_at' => ['date', 'onOrAfter:starts_at'],
         'cfp_starts_at' => ['date', 'before:starts_at'],

--- a/database/migrations/2019_04_07_152352_add_conference_location.php
+++ b/database/migrations/2019_04_07_152352_add_conference_location.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddConferenceLocation extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('conferences', function (Blueprint $table) {
+        	$table->string('location', 255)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('conferences', function (Blueprint $table) {
+            $table->dropColumn('location');
+        });
+    }
+}

--- a/resources/views/conferences/show.blade.php
+++ b/resources/views/conferences/show.blade.php
@@ -23,6 +23,11 @@
                 @endif
                 </p>
 
+                @unless ( empty($conference->location) )
+                    <p><b>Location:</b>
+                        {{ $conference->location}}</p>
+                @endunless
+
                 <p><b>Date created:</b>
                     {{ $conference->created_at->toFormattedDateString() }}</p>
 

--- a/resources/views/conferences/showPublic.blade.php
+++ b/resources/views/conferences/showPublic.blade.php
@@ -4,6 +4,11 @@
     <div class="container body">
         <h1>{{ $conference->title }}</h1>
 
+        @unless ( empty($conference->location) )
+            <p><b>Location:</b>
+                {{ $conference->location}}</p>
+        @endunless
+
         <p><b>Date created:</b>
             {{ $conference->created_at->toFormattedDateString() }}</p>
 

--- a/resources/views/partials/conferenceform.blade.php
+++ b/resources/views/partials/conferenceform.blade.php
@@ -4,6 +4,11 @@
 </div>
 
 <div class="form-group">
+    {!! Form::label('location', 'Location', ['class' => 'control-label']) !!}
+    {!! Form::text('location', $conference->location, ['class' => 'form-control']) !!}
+</div>
+
+<div class="form-group">
     {!! Form::label('description', '*Description', ['class' => 'control-label']) !!}
     {!! Form::textarea('description', $conference->description, ['class' => 'form-control']) !!}
 </div>

--- a/tests/ConferenceTest.php
+++ b/tests/ConferenceTest.php
@@ -16,6 +16,7 @@ class ConferenceTest extends IntegrationTestCase
         $this->actingAs($user)
             ->visit('/conferences/create')
             ->type('Das Conf', '#title')
+            ->type('Capital City, Country', '#location')
             ->type('A very good conference about things', '#description')
             ->type('http://dasconf.org', '#url')
             ->press('Create');


### PR DESCRIPTION
In #244 it was suggested to add location for the conference.  Specifically, city, state, post code, country, and possibly lat/lon were requested.  The story doesn't really describe the desired use cases, so here are a couple I can think of:
* Displaying conferences on a map (lat/lon)
* Filtering conferences by geographic region (hemisphere, continent, country, administrative levels?)
* Being able to quickly guestimate the location of the conference just by looking at the name

I implemented this based on the third bullet, mostly because of technical limitations, but also because State is too US-centric.

The data from JoindIn is completly unstructured, so a manual review and/or edit would be necessary for the conference importer.  Take for example [this one](https://api.joind.in/v2.1/events/7045) whose location is simply `University of York`.  Extrapolating that to `York YO10 5GE, United Kingdom` would require a geocoder service.

Therefore, my proposal is for a free text field; conferences can always be edited once imported.