### PR TITLE
Revert auth changes to web ConferencesController

### DIFF
--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use Carbon\Carbon;
 use App\Conference;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use App\Services\CreateConferenceForm;
 use Illuminate\Support\Facades\Session;
@@ -29,10 +28,10 @@ class ConferencesController extends BaseController
     {
         switch ($request->input('filter')) {
             case 'favorites':
-                $conferences = Auth::guard('api')->user()->favoritedConferences()->approved()->get();
+                $conferences = auth()->user()->favoritedConferences()->approved()->get();
                 break;
             case 'dismissed':
-                $conferences = Auth::guard('api')->user()->dismissedConferences()->approved()->get();
+                $conferences = auth()->user()->dismissedConferences()->approved()->get();
                 break;
             case 'open_cfp':
                 $conferences = Conference::undismissed()->openCfp()->approved()->get();
@@ -84,7 +83,7 @@ class ConferencesController extends BaseController
 
     public function store(Request $request)
     {
-        $form = CreateConferenceForm::fillOut($request->all(), Auth::guard('api')->user());
+        $form = CreateConferenceForm::fillOut($request->all(), auth()->user());
 
         try {
             $conference = $form->complete();
@@ -111,7 +110,7 @@ class ConferencesController extends BaseController
             return redirect('/');
         }
 
-        $talks = Auth::guard('api')->user()->talks->map(function ($talk) use ($conference) {
+        $talks = auth()->user()->talks->map(function ($talk) use ($conference) {
             return (TalkTransformer::transform($talk, $conference));
         });
 
@@ -132,8 +131,8 @@ class ConferencesController extends BaseController
     {
         $conference = Conference::findOrFail($id);
 
-        if ($conference->author_id !== auth()->id() && ! Auth::guard('api')->user()->isAdmin()) {
-            Log::error("User " . Auth::guard('api')->user()->id . " tried to edit a conference they don't own.");
+        if ($conference->author_id !== auth()->id() && ! auth()->user()->isAdmin()) {
+            Log::error("User " . auth()->user()->id . " tried to edit a conference they don't own.");
             return redirect('/');
         }
 
@@ -148,8 +147,8 @@ class ConferencesController extends BaseController
         // @todo Update this to use ACL... gosh this app is old...
         $conference = Conference::findOrFail($id);
 
-        if ($conference->author_id !== auth()->id() && ! Auth::guard('api')->user()->isAdmin()) {
-            Log::error("User " . Auth::guard('api')->user()->id . " tried to edit a conference they don't own.");
+        if ($conference->author_id !== auth()->id() && ! auth()->user()->isAdmin()) {
+            Log::error("User " . auth()->user()->id . " tried to edit a conference they don't own.");
             return redirect('/');
         }
 
@@ -160,7 +159,7 @@ class ConferencesController extends BaseController
             $conference->$col = $request->input($col) ?: null;
         }
 
-        if (Auth::guard('api')->user()->isAdmin()) {
+        if (auth()->user()->isAdmin()) {
             $conference->is_shared = $request->input('is_shared');
             $conference->is_approved = $request->input('is_approved');
         }
@@ -175,9 +174,9 @@ class ConferencesController extends BaseController
     public function destroy($id)
     {
         try {
-            $conference = Auth::guard('api')->user()->conferences()->findOrFail($id);
+            $conference = auth()->user()->conferences()->findOrFail($id);
         } catch (Exception $e) {
-            Log::error("User " . Auth::guard('api')->user()->id . " tried to delete a conference that doesn't exist or they don't own.");
+            Log::error("User " . auth()->user()->id . " tried to delete a conference that doesn't exist or they don't own.");
             return redirect('/');
         }
 
@@ -194,14 +193,14 @@ class ConferencesController extends BaseController
             return redirect()->back();
         }
 
-        Auth::guard('api')->user()->dismissedConferences()->attach($conferenceId);
+        auth()->user()->dismissedConferences()->attach($conferenceId);
 
         return redirect()->back();
     }
 
     public function undismiss($conferenceId)
     {
-        Auth::guard('api')->user()->dismissedConferences()->detach($conferenceId);
+        auth()->user()->dismissedConferences()->detach($conferenceId);
 
         return redirect()->back();
     }
@@ -212,14 +211,14 @@ class ConferencesController extends BaseController
             return redirect()->back();
         }
 
-        Auth::guard('api')->user()->favoritedConferences()->attach($conferenceId);
+        auth()->user()->favoritedConferences()->attach($conferenceId);
 
         return redirect()->back();
     }
 
     public function unfavorite($conferenceId)
     {
-        Auth::guard('api')->user()->favoritedConferences()->detach($conferenceId);
+        auth()->user()->favoritedConferences()->detach($conferenceId);
 
         return redirect()->back();
     }


### PR DESCRIPTION
This PR reverts auth-related changes that were made to the web version of `ConferencesController` (i.e. requiring an explicit reference to the `api` guard) that were only intended for API controllers.