### PR TITLE
Disable email registration

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -18,7 +18,8 @@
                     <p>Symposium <b>will be</b> a single place for <strong>conference organizers</strong> to open CFPs, review speakers submissions, and manage the entire CFP process.</p>
                 </div>
                 <div class="col-md-4">
-                    @if (Auth::guest())
+                    {{-- Disable email registration --}}
+                    @if (false && Auth::guest())
                         <div class="panel panel-default panel-on-grey">
                             <div class="panel-heading">
                               <h3 class="panel-title">Sign up</h3>

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -23,7 +23,8 @@
             <li><a href="{{ url('speakers') }}">Our speakers</a></li>
             <li><a href="{{ route('conferences.index') }}">Conferences</a></li>
             <li><a href="{{ route('login') }}">Log in</a></li>
-            <li><a href="{{ route('register') }}">Sign up</a></li>
+            {{-- Disable email registration --}}
+            {{-- <li><a href="{{ route('register') }}">Sign up</a></li> --}}
         @endif
     </ul>
 </nav>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,10 +48,6 @@ Route::get('log-out', ['as' => 'log-out', 'uses' => 'Auth\LoginController@logout
 // Disable email registration
 Auth::routes(['register' => false]);
 
-// Route::get('sign-up', function () {
-//     return redirect('register');
-// });
-
 Route::group(['middleware' => 'auth'], function () {
     Route::get('account', ['as' => 'account.show', 'uses' => 'AccountController@show']);
     Route::get('account/edit', ['as' => 'account.edit', 'uses' => 'AccountController@edit']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,11 +45,12 @@ Route::post('u/{profileSlug}/email', [
  */
 Route::get('log-out', ['as' => 'log-out', 'uses' => 'Auth\LoginController@logout']);
 
-Auth::routes();
+// Disable email registration
+Auth::routes(['register' => false]);
 
-Route::get('sign-up', function () {
-    return redirect('register');
-});
+// Route::get('sign-up', function () {
+//     return redirect('register');
+// });
 
 Route::group(['middleware' => 'auth'], function () {
     Route::get('account', ['as' => 'account.show', 'uses' => 'AccountController@show']);

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -16,6 +16,8 @@ class AccountTest extends IntegrationTestCase
     /** @test */
     function users_can_sign_up()
     {
+        $this->markTestSkipped('Disable email registration');
+
         $this->visit('register')
             ->type('email@email.com', '#email')
             ->type('schmassword', '#password')
@@ -32,6 +34,8 @@ class AccountTest extends IntegrationTestCase
     /** @test */
     function invalid_signups_dont_proceed()
     {
+        $this->markTestSkipped('Disable email registration');
+
         $this->visit('register')
             ->press('Sign up')
             ->see('The name field is required')


### PR DESCRIPTION
This PR disables the ability to register for a new account with an email address by disabling the registration routes and removing the registration form and sign up link from the home page.  Visiting `/register` or making a post request to `/register` will result in a `404`.

Sign up link removed from nav bar
![image](https://user-images.githubusercontent.com/1121383/68488051-dfbeb500-0209-11ea-8397-a9ed0d11c72c.png)

Email registration form removed from home page
![image](https://user-images.githubusercontent.com/1121383/68488097-f402b200-0209-11ea-94b6-583ec13b9711.png)


