### PR TITLE
Fix intermittent errors with bio nickname tests

### DIFF
--- a/tests/PublicSpeakerProfileTest.php
+++ b/tests/PublicSpeakerProfileTest.php
@@ -144,7 +144,9 @@ class PublicSpeakerProfileTest extends IntegrationTestCase
             'enable_profile' => true,
         ]);
 
-        $bio = factory(Bio::class)->create();
+        $bio = factory(Bio::class)->create([
+            'nickname' => 'Private Bio'
+        ]);
         $bio->public = false;
         $user->bios()->save($bio);
 


### PR DESCRIPTION
It looks like we're running into intermittent errors with `PublicSpeakerProfileTest::bios_marked_not_public_do_not_have_public_pages`. From what I can tell, it's from overly generic results being generated by the `Bio` factory for the `nickname` attribute (Failing examples: "in", "aut"). 

This change should fix any unintended matches in the response.