### PR TITLE
Only show approved conferences on the calendar page

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -21,7 +21,7 @@ class CalendarController extends BaseController
 
     private function conferenceEvents()
     {
-        return Conference::all()->reject(function ($conference) {
+        return Conference::approved()->get()->reject(function ($conference) {
             return $conference->startsAtSet() === null || $conference->endsAtSet() === null;
         })->map(function ($conference) {
             return Calendar::event(
@@ -40,7 +40,7 @@ class CalendarController extends BaseController
 
     private function cfpStartEvents()
     {
-        return Conference::all()->reject(function (Conference $conference) {
+        return Conference::approved()->get()->reject(function (Conference $conference) {
             return $conference->cfpStartsAtSet() === null;
         })->map(function ($conference) {
             return Calendar::event(
@@ -59,7 +59,7 @@ class CalendarController extends BaseController
 
     private function cfpEndEvents()
     {
-        return Conference::all()->reject(function (Conference $conference) {
+        return Conference::approved()->get()->reject(function (Conference $conference) {
             return $conference->cfpEndsAtSet() === null;
         })->map(function ($conference) {
             return Calendar::event(

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Conference;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CalendarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function unapproved_conferences_do_not_appear_on_the_calendar()
+    {
+        $user = factory(User::class)->create();
+
+        factory(Conference::class)->create([
+            'title' => 'Unapproved conference',
+            'is_approved' => false,
+        ]);
+
+        factory(Conference::class)->create([
+            'title' => 'Approved conference',
+            'is_approved' => true,
+        ]);
+
+        $this->actingAs($user)->get('calendar')
+            ->assertResponseOk()
+            ->see('Approved conference')
+            ->dontSee('Unapproved conference');
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This PR scopes the conferences, CFP start dates, and CFP end dates that display on the calendar page to those that are approved (`is_approved = 1`). This will enable us to mark a previously approved conference as not approved and prevent it from appearing on the calendar.

This addresses a concern raised in #310 