### PR TITLE
Add acceptances filter

### DIFF
--- a/app/Http/Controllers/TalksController.php
+++ b/app/Http/Controllers/TalksController.php
@@ -31,9 +31,7 @@ class TalksController extends BaseController
     public function index(Request $request)
     {
         $talks = $this->sortTalks(
-            $request->input('filter') === 'submitted'
-                ? auth()->user()->talks()->submitted()->get()
-                : auth()->user()->talks()->active()->get(),
+            $this->filterTalks($request->input('filter')),
             $request->input('sort')
         );
 
@@ -186,6 +184,21 @@ class TalksController extends BaseController
         Session::flash('success-message', 'Successfully restored talk.');
 
         return redirect('archive');
+    }
+
+    private function filterTalks($filter)
+    {
+        switch ($filter) {
+            case 'submitted':
+                return auth()->user()->talks()->submitted()->get();
+                break;
+            case 'accepted':
+                return auth()->user()->talks()->accepted()->get();
+                break;
+            default:
+                return auth()->user()->talks()->active()->get();
+                break;
+        }
     }
 
     private function sortTalks($talks, $sort)

--- a/app/Talk.php
+++ b/app/Talk.php
@@ -27,6 +27,11 @@ class Talk extends UuidBase
         return $this->hasManyThrough(Submission::class, TalkRevision::class);
     }
 
+    public function acceptances()
+    {
+        return $this->hasManyThrough(Acceptance::class, TalkRevision::class);
+    }
+
     public function current()
     {
         return $this->revisions()->orderBy('created_at', 'DESC')->first();
@@ -77,6 +82,11 @@ class Talk extends UuidBase
     public function scopeSubmitted($query)
     {
         $query->has('submissions');
+    }
+
+    public function scopeAccepted($query)
+    {
+        $query->has('acceptances');
     }
 
     public function getMySubmissionForConference(Conference $conference)

--- a/resources/views/talks/index.blade.php
+++ b/resources/views/talks/index.blade.php
@@ -21,6 +21,11 @@
                 'route' => 'talks.index',
                 'query' => ['filter' => 'submitted'],
             ],
+            'accepted' => [
+                'label' => 'Accepted',
+                'route' => 'talks.index',
+                'query' => ['filter' => 'accepted'],
+            ],
         ]"
         :defaults="['filter' => 'active', 'sort' => 'alpha']"
     ></x-side-menu>


### PR DESCRIPTION
Adds a filter to the `talks.index` page to show only talks with accepted `talk_revisions`.
![Oct-28-2021 10-32-57](https://user-images.githubusercontent.com/4378273/139277668-4103b757-3ae0-4b56-90a2-432815541bbd.gif)


