### PR TITLE
Update script to match deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "private": true,
     "scripts": {
-        "production": "vite build",
         "dev": "vite",
-        "build": "vite build"
+        "build": "vite build",
+        "prod": "vite build"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.0",


### PR DESCRIPTION
This PR renames the `production` npm script to `prod` to match the deployment script.